### PR TITLE
Deploy with explicit tag

### DIFF
--- a/lib/heroku-rails-saas/runner.rb
+++ b/lib/heroku-rails-saas/runner.rb
@@ -130,7 +130,7 @@ module HerokuRailsSaas
           creation_command "heroku config:add #{set_config} --app #{app_name}"
 
           # This fails on a newly created app
-          system_with_echo("#{@config.cmd(app_env)} \"#{rails_cli(:runner)} 'Rails.cache.clear'\" --app #{app_name}")
+          system_with_echo("heroku run \"#{rails_cli(:runner)} 'Rails.cache.clear'\" --app #{app_name}")
         end
       end
     end

--- a/lib/heroku-rails-saas/runner.rb
+++ b/lib/heroku-rails-saas/runner.rb
@@ -54,10 +54,10 @@ module HerokuRailsSaas
         heroku_app_info = @heroku.info(app_name) || {}
 
         # if the stacks don't match, then perform a migration
-        if stack != heroku_app_info[:stack]
-          puts "Migrating the app: #{app_name} to the stack: #{stack}"
-          creation_command "heroku stack:migrate #{stack} --app #{app_name}"
-        end
+        # if stack != heroku_app_info[:stack]
+        #   puts "Migrating the app: #{app_name} to the stack: #{stack}"
+        #   creation_command "heroku stack:migrate #{stack} --app #{app_name}"
+        # end
       end
     end
 

--- a/lib/heroku/rails/tasks.rb
+++ b/lib/heroku/rails/tasks.rb
@@ -106,7 +106,7 @@ namespace :heroku do
       @git_push_arguments << '--force'
 
       # ^0 is required so git dereferences the tag into a commit SHA (else Heroku's git server will throw up)
-      system_with_echo "git push #{repo} #{@git_push_arguments.join(' ')} #{to_deploy}^0:refs/heads/master"
+      system_with_echo "git push #{repo} #{@git_push_arguments.uniq.join(' ')} #{to_deploy}^0:refs/heads/master"
 
       system_with_echo "heroku maintenance:on --app #{app_name}"
 

--- a/lib/heroku/rails/tasks.rb
+++ b/lib/heroku/rails/tasks.rb
@@ -105,7 +105,8 @@ namespace :heroku do
       @git_push_arguments ||= []
       @git_push_arguments << '--force'
 
-      system_with_echo "git push #{repo} #{@git_push_arguments.join(' ')} #{to_deploy}:master"
+      # ^0 is required so git dereferences the tag into a commit SHA (else Heroku's git server will throw up)
+      system_with_echo "git push #{repo} #{@git_push_arguments.join(' ')} #{to_deploy}^0:refs/heads/master"
 
       system_with_echo "heroku maintenance:on --app #{app_name}"
 


### PR DESCRIPTION
Make it possible to deploy the same code to a series of targets:

```
rake all:production heroku:deploy[v2.10.0]
```

By explicitly specifying an existing tag (`v2.10.0` in the example above) on the command line, rake will no longer prompt the user for the tag to deploy for each deploy of the `all` series.
